### PR TITLE
Update dlg_import_vector.py

### DIFF
--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -132,7 +132,7 @@ class DlgImportVector(QDialog, Ui_Dialog):
         for nodeLayer in QgsProject.instance().layerTreeRoot().findLayers():
             layer = nodeLayer.layer()
             # TODO: add import raster support!
-            if layer != None and layer.type() == QgsMapLayerType.VectorLayer:
+            if layer is not None and layer.type() == QgsMapLayerType.VectorLayer:
                 self.cboInputLayer.addItem(layer.name(), layer.id())
 
     def deleteInputLayer(self):


### PR DESCRIPTION
This change will make the db managers import function more robust towards (some types of) invalid layers. cf issue #41152

Before trying to read the type of the layer when compling them for the drop down box, it checks if the layer value is of NoneType. This should not happen, but at least for some usage of the open layer plugin, a layer may end up as none type.

I have observed this issue in several earlier versions of qgis and the code has not been changed since at least 3.10 LTR, so it could, and probably should be backported to 3.10

Fixes  #41152